### PR TITLE
Create unit tests + fix unmatched curly braces

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,7 @@
+# Ignore build and test output
+config_parser
+config_parser_test
+libgtest.a
+
+# Ignore macOS debugging symbols
+config_parser.dSYM*

--- a/clean.sh
+++ b/clean.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+rm config_parser
+rm config_parser_test
+rm *.dSYM

--- a/config_parser.cc
+++ b/config_parser.cc
@@ -129,7 +129,7 @@ NginxConfigParser::TokenType NginxConfigParser::ParseToken(std::istream* input,
         *value += c;
         continue;
       case TOKEN_STATE_TOKEN_TYPE_NORMAL:
-        if (c == ' ' || c == '\t' || c == '\n' || c == '\t' ||
+        if (c == ' ' || c == '\t' || c == '\n' ||
             c == ';' || c == '{' || c == '}') {
           input->unget();
           return TOKEN_TYPE_NORMAL;

--- a/config_parser_test.cc
+++ b/config_parser_test.cc
@@ -55,8 +55,19 @@ TEST_F(NginxStringConfigTest, NestedConfig) {
     << "Child block should be parsed properly for nested NginxConfig";
 }
 
-// TODO: Unmatched curly braces {}: +1 for {, -1 for }
-// TODO: Comments in a config file: # This is a comment
+TEST_F(NginxStringConfigTest, UnmatchedCurlyBracesOpening) {
+  EXPECT_FALSE(ParseString("server  location / { expires 30d; } }"));
+}
+
+TEST_F(NginxStringConfigTest, UnmatchedCurlyBracesClosing) {
+  EXPECT_FALSE(ParseString("server { location / { expires 30d; } "));
+}
+
+TEST_F(NginxStringConfigTest, UnmatchedCurlyBracesNestedOpening) {
+  EXPECT_FALSE(ParseString("server { location /  expires 30d; } }"));
+}
+
+// TODO: A blank config or one with only comments is a useless config
 // TODO: 2 levels of nesting: foo { bar { choo }}
 // TODO: There may be other bugs
 

--- a/config_parser_test.cc
+++ b/config_parser_test.cc
@@ -8,13 +8,6 @@
 // An NginxConfig consists of 1 or more NginxConfigStatement's,
 // which may in turn have a nested NginxConfig.
 
-TEST(NginxConfigTest, ToString) {
-  NginxConfigStatement statement;
-  statement.tokens_.push_back("foo");
-  statement.tokens_.push_back("bar");
-  EXPECT_EQ(statement.ToString(0), "foo bar;\n");
-}
-
 // Test NginxConfigParser::Parse() with config strings
 // (as opposed to full-on files)
 class NginxStringConfigTest : public ::testing::Test {
@@ -75,4 +68,13 @@ TEST_F(NginxStringConfigTest, BlankConfig) {
 
 TEST_F(NginxStringConfigTest, CommentsOnlyConfig) {
   EXPECT_FALSE(ParseString("# This comment does nothing"));
+}
+
+// Whole-module checks
+
+TEST(NginxConfigTest, ToString) {
+  NginxConfigStatement statement;
+  statement.tokens_.push_back("foo");
+  statement.tokens_.push_back("bar");
+  EXPECT_EQ(statement.ToString(0), "foo bar;\n");
 }

--- a/config_parser_test.cc
+++ b/config_parser_test.cc
@@ -78,3 +78,9 @@ TEST(NginxConfigTest, ToString) {
   statement.tokens_.push_back("bar");
   EXPECT_EQ(statement.ToString(0), "foo bar;\n");
 }
+
+TEST(NginxConfigParser, DoubleVhostConfig) {
+  NginxConfigParser parser;
+  NginxConfig out_config_;
+  EXPECT_TRUE(parser.Parse("two_hosts_config", &out_config_));
+}

--- a/config_parser_test.cc
+++ b/config_parser_test.cc
@@ -67,7 +67,16 @@ TEST_F(NginxStringConfigTest, UnmatchedCurlyBracesNestedOpening) {
   EXPECT_FALSE(ParseString("server { location /  expires 30d; } }"));
 }
 
-// TODO: A blank config or one with only comments is a useless config
-// TODO: 2 levels of nesting: foo { bar { choo }}
+// A blank config or one with only comments is a useless config
+TEST_F(NginxStringConfigTest, BlankConfig) {
+  EXPECT_FALSE(ParseString(""));
+}
+
+TEST_F(NginxStringConfigTest, CommentsOnlyConfig) {
+  EXPECT_FALSE(ParseString("# This comment does nothing"));
+}
+
+// TODO: Unmatched quotes, single and double
+// TODO: 2 levels of nesting: foo { bar { choo } }
 // TODO: There may be other bugs
 

--- a/config_parser_test.cc
+++ b/config_parser_test.cc
@@ -1,11 +1,25 @@
-#include "gtest/gtest.h"
+#include <iostream>
 #include "config_parser.h"
+#include "gtest/gtest.h"
 
-TEST(NginxConfigParserTest, SimpleConfig) {
-  NginxConfigParser parser;
-  NginxConfig out_config;
+// Test fixture to hold parser and parsed result
+// Fresh fixture instances are created for every test case
+class NginxConfigParserTest : public ::testing::Test {
+protected:
+    // No SetUp or TearDown required here
+    NginxConfigParser parser;
+    NginxConfig out_config;
+};
 
+TEST_F(NginxConfigParserTest, SimpleConfig) {
   bool success = parser.Parse("example_config", &out_config);
+  std::cerr << out_config.ToString() << std::endl;
 
-  EXPECT_TRUE(success);
+  ASSERT_TRUE(success);
+}
+
+TEST_F(NginxConfigParserTest, EmptyConfig) {
+    bool failure = parser.Parse("", &out_config);
+
+    ASSERT_FALSE(failure);
 }

--- a/config_parser_test.cc
+++ b/config_parser_test.cc
@@ -50,24 +50,29 @@ TEST_F(NginxStringConfigTest, NestedConfig) {
 }
 
 TEST_F(NginxStringConfigTest, UnmatchedCurlyBracesOpening) {
-  EXPECT_FALSE(ParseString("server  location / { expires 30d; } }"));
+  EXPECT_FALSE(ParseString("server  location / { expires 30d; } }"))
+    << "Statements with a missing opening curly brace should not be accepted";
 }
 
 TEST_F(NginxStringConfigTest, UnmatchedCurlyBracesClosing) {
-  EXPECT_FALSE(ParseString("server { location / { expires 30d; } "));
+  EXPECT_FALSE(ParseString("server { location / { expires 30d; } "))
+    << "Statements with a missing closing curly brace should not be accepted";
 }
 
 TEST_F(NginxStringConfigTest, UnmatchedCurlyBracesNestedOpening) {
-  EXPECT_FALSE(ParseString("server { location /  expires 30d; } }"));
+  EXPECT_FALSE(ParseString("server { location /  expires 30d; } }"))
+    << "Nested statedments with a missing opening curly brace should not be accepted";
 }
 
 // A blank config or one with only comments is a useless config
 TEST_F(NginxStringConfigTest, BlankConfig) {
-  EXPECT_FALSE(ParseString(""));
+  EXPECT_FALSE(ParseString(""))
+    << "Config files with no contents should not be accepted";
 }
 
 TEST_F(NginxStringConfigTest, CommentsOnlyConfig) {
-  EXPECT_FALSE(ParseString("# This comment does nothing"));
+  EXPECT_FALSE(ParseString("# This comment does nothing"))
+    << "Config files with only comments should not be accepted";
 }
 
 // Whole-module checks
@@ -76,11 +81,13 @@ TEST(NginxConfigTest, ToString) {
   NginxConfigStatement statement;
   statement.tokens_.push_back("foo");
   statement.tokens_.push_back("bar");
-  EXPECT_EQ(statement.ToString(0), "foo bar;\n");
+  EXPECT_EQ(statement.ToString(0), "foo bar;\n")
+    << "NginxConfigStatement::ToString() output does not match statement contents";
 }
 
 TEST(NginxConfigParser, DoubleVhostConfig) {
   NginxConfigParser parser;
   NginxConfig out_config_;
-  EXPECT_TRUE(parser.Parse("two_hosts_config", &out_config_));
+  EXPECT_TRUE(parser.Parse("two_hosts_config", &out_config_))
+    << "Config file with 2 vhosts should parse";
 }

--- a/config_parser_test.cc
+++ b/config_parser_test.cc
@@ -8,8 +8,7 @@
 // An NginxConfig consists of 1 or more NginxConfigStatement's,
 // which may in turn have a nested NginxConfig.
 
-// Test NginxConfigStatement::ToString()
-TEST(NginxConfigTest, ToStringTokens) {
+TEST(NginxConfigTest, ToString) {
   NginxConfigStatement statement;
   statement.tokens_.push_back("foo");
   statement.tokens_.push_back("bar");
@@ -32,10 +31,12 @@ protected:
 
 // Check the internal representation of "foo bar;"
 // TODO: rename tests to be systematic and meaningful
-TEST_F(NginxStringConfigTest, AnotherSimpleConfig) {
+TEST_F(NginxStringConfigTest, StatementsAndTokensState) {
   EXPECT_TRUE(ParseString("foo bar;"));
   EXPECT_EQ(1, out_config_.statements_.size())
-    << "Config should have exactly one statement";
+    << "Config should have exactly 1 statement";
+  EXPECT_EQ(2, out_config_.statements_[0]->tokens_.size())
+    << "Config should have exactly 2 tokens in its 1st statement";
   EXPECT_EQ("foo", out_config_.statements_[0]->tokens_[0]);
 }
 
@@ -75,8 +76,3 @@ TEST_F(NginxStringConfigTest, BlankConfig) {
 TEST_F(NginxStringConfigTest, CommentsOnlyConfig) {
   EXPECT_FALSE(ParseString("# This comment does nothing"));
 }
-
-// TODO: Unmatched quotes, single and double
-// TODO: 2 levels of nesting: foo { bar { choo } }
-// TODO: There may be other bugs
-

--- a/config_parser_test.cc
+++ b/config_parser_test.cc
@@ -31,21 +31,32 @@ protected:
 };
 
 // Check the internal representation of "foo bar;"
+// TODO: rename tests to be systematic and meaningful
 TEST_F(NginxStringConfigTest, AnotherSimpleConfig) {
   EXPECT_TRUE(ParseString("foo bar;"));
   EXPECT_EQ(1, out_config_.statements_.size())
-    << "Config has one statement";
+    << "Config should have exactly one statement";
   EXPECT_EQ("foo", out_config_.statements_[0]->tokens_[0]);
 }
 
-// Invalid config should fail (missing semicolon)
-TEST_F(NginxStringConfigTest, InvalidConfig) {
+TEST_F(NginxStringConfigTest, MissingSemicolon) {
   EXPECT_FALSE(ParseString("foo bar"));
 }
 
-// TODO: Unbalanced {} should not parse
-// There is at least 1 other bug
+// Single statement, but it should have an NginxConfig child_block_
 TEST_F(NginxStringConfigTest, NestedConfig) {
   EXPECT_TRUE(ParseString("server { listen 80; }"));
-  // TODO: Test the contents of out_config_;
+  EXPECT_EQ(1, out_config_.statements_.size());
+  EXPECT_TRUE(out_config_.statements_[0]->child_block_.get() != nullptr)
+    << "Child block should exist for nested NginxConfig";
+
+  EXPECT_EQ(2, out_config_.statements_[0]->child_block_
+                                         ->statements_[0]->tokens_.size())
+    << "Child block should be parsed properly for nested NginxConfig";
 }
+
+// TODO: Unmatched curly braces {}: +1 for {, -1 for }
+// TODO: Comments in a config file: # This is a comment
+// TODO: 2 levels of nesting: foo { bar { choo }}
+// TODO: There may be other bugs
+

--- a/two_hosts_config
+++ b/two_hosts_config
@@ -1,0 +1,13 @@
+server {
+    listen          80;
+    server_name     domain.com *.domain.com;
+    return          301 $scheme://www.domain.com$request_uri;
+ }
+
+server {
+    listen          80;
+    server_name     www.domain.com;
+
+    index           index.html;
+    root            /home/domain.com;
+}


### PR DESCRIPTION
This introduces unit tests and also fixes the parser's handling of unmatched curly braces. For example, `server { location / { expires 30d; }` is an invalid config that previously parsed successfully.